### PR TITLE
Fix licence string

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "testing"
   ],
   "author": "Philippe Le Hégaret",
-  "license": "W3C Software License",
+  "license": "W3C",
   "bugs": {
     "url": "https://github.com/w3c/hanuman/issues"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "testing"
   ],
   "author": "Philippe Le Hégaret",
-  "license": "W3C",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/w3c/hanuman/issues"
   },


### PR DESCRIPTION
@wseltzer, on [the list of available SPDX licences](https://spdx.org/licenses/) I found two related to W3C: [`W3C-19980720`](https://spdx.org/licenses/W3C-19980720.html) and [`W3C`](https://spdx.org/licenses/W3C.html). Do those look right to you? I chose the latter for this repo.

@plehegar, is [this](https://spdx.org/licenses/W3C.html#licenseText) the right licence text for _Hanuman_?

(Fixes #2).
